### PR TITLE
Meaningful error for failed userProfile requests

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -178,7 +178,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
     try {
       json = JSON.parse(body);
     } catch (ex) {
-      return done(ex);
+      return done('Could not parse JSON response: ' + ex.message);
     }
 
     var profile = Profile.parse(json);


### PR DESCRIPTION
Instead of giving the full exception, call `done()` with a meaningful error message.