### PR TITLE
Fixes to make the module work with OAuth Server

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -82,57 +82,7 @@ util.inherits(Strategy, OAuth2Strategy);
  */
 Strategy.prototype.authenticate = function(req, options) {
   options = options || {};
-  var self = this;
-
-  if (req && req.query && req.query.error) {
-    return self.error('Request not provided or has errors');
-  }
-
-  if (!req.body) {
-    return self.error();
-  }
-
-  if (!req.body.redirectUri) {
-    return self.error('You need to provide a redirectUri');
-  } else {
-    self._callbackURL = req.body.redirectUri;
-  }
-
-  var authCode =  req.body.code || req.query.code;
-
-  if (!authCode) {
-    return self.error();
-  }
-
-  self._exchangeAuthCode(authCode,
-    function(error, accessToken, refreshToken, results) {
-      if (error) {
-        return self.error(error);
-      }
-
-      self.userProfile(accessToken, function(err, profile) {
-        if (err) {
-          return self.fail(err);
-        }
-
-        var verified = function(e, user, info) {
-          if (e) {
-            return self.error(e);
-          }
-          if (!user) {
-            return self.fail(info);
-          }
-
-          self.success(user, info);
-        };
-
-        if (self._passReqToCallback) {
-          self._verify(req, accessToken, refreshToken, profile, verified);
-        } else {
-          self._verify(accessToken, refreshToken, profile, verified);
-        }
-      });
-    });
+  OAuth2Strategy.prototype.authenticate.call(this, req, options)
 };
 
 
@@ -168,6 +118,10 @@ Strategy.prototype._exchangeAuthCode = function(authCode, done) {
  * @api protected
  */
 Strategy.prototype.userProfile = function(accessToken, done) {
+
+  this._oauth2.useAuthorizationHeaderforGET(true);
+  this._oauth2.setAuthMethod('Bearer');
+
   this._oauth2.get(this._userProfileURL, accessToken, function(err, body, res) {
     var json;
 

--- a/test/profile.test.js
+++ b/test/profile.test.js
@@ -74,7 +74,7 @@ describe('profile.parse', function() {
     it('should throw an error', function() {
       expect(error).to.not.be.undefined;
       expect(error.name).to.equal('SyntaxError');
-      expect(error.message).to.equal('Unexpected token /');
+      expect(error.message).to.equal('Unexpected token / in JSON at position 4');
     });
   });
 });

--- a/test/strategy.profile.test.js
+++ b/test/strategy.profile.test.js
@@ -93,7 +93,7 @@ describe('Strategy#userProfile', function() {
     it('call the callback with an error object', function() {
       expect(error).to.not.be.undefined;
       expect(error.name).to.equal('SyntaxError');
-      expect(error.message).to.equal('Unexpected token .');
+      expect(error.message).to.equal('Unexpected token . in JSON at position 63');
     });
   });
 


### PR DESCRIPTION
I was unable to use the passport-oauth without changes, when testing with both wordpress.com and a local wordpress server using "OAuth Server" plugin. Have made changes to make it work with both environments.

Also modified test cases, since the JSON.parse() method seems to have changed the error message it gives, versus what the test cases were expecting.